### PR TITLE
add camera server

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -4,6 +4,7 @@
 
 package frc.robot;
 
+import edu.wpi.first.cameraserver.CameraServer;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
@@ -26,10 +27,12 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void robotInit() {
-    // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
-    // autonomous chooser on the dashboard.
-
+    // Instantiate our RobotContainer.
+    // This will perform all our button bindings, and put our autonomous chooser on the dashboard.
     m_robotContainer = new RobotContainer();
+
+    // Camera will start capturing frames and sending them to the dashboard
+    CameraServer.startAutomaticCapture(); 
   }
 
   /**


### PR DESCRIPTION
imported library + runs method that allows the camera to start automatically capturing frames and sending them to the dashboard

[wpilib camera server instructions](https://docs.wpilib.org/en/stable/docs/software/vision-processing/roborio/using-the-cameraserver-on-the-roborio.html)

[camera server class documentation](https://first.wpi.edu/wpilib/allwpilib/docs/release/java/edu/wpi/first/cameraserver/CameraServer.html)